### PR TITLE
Rails 6 support

### DIFF
--- a/lib/prx_auth/rails/configuration.rb
+++ b/lib/prx_auth/rails/configuration.rb
@@ -5,8 +5,13 @@ class PrxAuth::Rails::Configuration
     @install_middleware = true
     if defined?(::Rails)
       klass = ::Rails.application.class
-      klass_name = if klass.parent_name.present?
-                     klass.parent_name
+      parent_name = if Rails::VERSION::MAJOR >= 6
+                      klass.module_parent_name
+                    else
+                      klass.parent_name
+                    end
+      klass_name = if parent_name.present?
+                     parent_name
                    else
                      klass.name
                    end

--- a/lib/prx_auth/rails/configuration.rb
+++ b/lib/prx_auth/rails/configuration.rb
@@ -5,7 +5,7 @@ class PrxAuth::Rails::Configuration
     @install_middleware = true
     if defined?(::Rails)
       klass = ::Rails.application.class
-      parent_name = if Rails::VERSION::MAJOR >= 6
+      parent_name = if ::Rails::VERSION::MAJOR >= 6
                       klass.module_parent_name
                     else
                       klass.parent_name

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -1,5 +1,5 @@
 module PrxAuth
   module Rails
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end


### PR DESCRIPTION
Rails 6.1 will rename `Module#parent_name` to `Module#module_parent_name`.  Support either.