### PR TITLE
Feat/current user widget

### DIFF
--- a/app/assets/javascripts/prx_auth-rails/user_widget.js.erb
+++ b/app/assets/javascripts/prx_auth-rails/user_widget.js.erb
@@ -12,15 +12,17 @@ function prxInjectScript(src, callback) {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  const idHost = 'https://<%= PrxAuth::Rails.configuration.id_host %>';
+
+  const widget = document.getElementById('prx-user-widget');
+  const account = document.getElementById('prx-user-widget-menu-account');
+
+  const idHost = 'https://' + widget.getAttribute('data-id-host');;
   const scriptUrl = idHost + '/widget.js';
 
   prxInjectScript(scriptUrl, function () {
     const signIn = new PRXSignIn(idHost);
 
     signIn.signedIn(function (prx) {
-      const widget = document.getElementById('prx-user-widget');
-      const account = document.getElementById('prx-user-widget-menu-account');
 
       if (!prx.userinfo) {
         // Not logged in


### PR DESCRIPTION
Fixes #11 This use a data attribute to pass the id host parameter into the user widget.  Works around not having to precompile assets in the app bootup to snag ENV vals (instead precompile at docker build time).