### PR TITLE
Refreshable JWT

### DIFF
--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -48,9 +48,14 @@ module PrxAuth::Rails
     private
 
     def after_sign_in_path_for(_)
-      return super if defined?(super)
-
-      "/"
+      back_path = after_sign_in_user_redirect
+      if back_path.present?
+        back_path
+      elsif defined?(super)
+        super
+      else
+        '/'
+      end
     end
 
     def after_sign_out_path

--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -38,7 +38,6 @@ module PrxAuth::Rails
       if valid_nonce? && users_match?
         clear_nonce!
         sign_in_user(access_token)
-        lookup_and_register_accounts_names
         redirect_to after_sign_in_path_for(current_user)
       else
         clear_nonce!

--- a/lib/prx_auth/rails/engine.rb
+++ b/lib/prx_auth/rails/engine.rb
@@ -2,7 +2,10 @@ module PrxAuth
   module Rails
     class Engine < ::Rails::Engine
       config.to_prepare do
-        ::ApplicationController.helper_method [:current_user, :account_name_for]
+        ::ApplicationController.helper_method [
+          :current_user, :prx_jwt,
+          :account_name_for, :account_for, :accounts_for,
+        ]
       end
     end
   end

--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -32,11 +32,10 @@ module PrxAuth
       end
 
       def sign_out_user
-        session.delete(PRX_JWT_SESSION_KEY)
-        session.delete(PRX_ACCOUNT_MAPPING_SESSION_KEY)
+        reset_session
       end
 
-      def account_name_for(id)
+      def account_name_for(account_id)
         account_for(account_id)[:name]
       end
 

--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -20,6 +20,10 @@ module PrxAuth
         redirect_to PrxAuth::Rails::Engine.routes.url_helpers.new_sessions_path
       end
 
+      def prx_jwt
+        session[PRX_JWT_SESSION_KEY]
+      end
+
       def prx_authenticated?
         !!prx_auth_token
       end
@@ -97,11 +101,9 @@ module PrxAuth
 
       # token from jwt stored in session
       def session_token
-        @session_prx_auth_token ||= if session[PRX_JWT_SESSION_KEY]
-          jwt = session[PRX_JWT_SESSION_KEY]
-
+        @session_prx_auth_token ||= if prx_jwt
           # NOTE: we already validated this jwt - so just decode it
-          validator = Rack::PrxAuth::AuthValidator.new(jwt)
+          validator = Rack::PrxAuth::AuthValidator.new(prx_jwt)
 
           # try to refresh auth session on GET requests
           if request.get? && validator.time_to_live < PRX_JWT_REFRESH_TTL

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -1,5 +1,5 @@
 module PrxAuth
   module Rails
-    VERSION = "1.7.0"
+    VERSION = "1.8.0"
   end
 end

--- a/prx_auth-rails.gemspec
+++ b/prx_auth-rails.gemspec
@@ -8,10 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = PrxAuth::Rails::VERSION
   spec.authors       = ["Chris Rhoden"]
   spec.email         = ["carhoden@gmail.com"]
-  spec.description   = %q{Rails integration for next generation PRX Authorization system.
-}
-  spec.summary       = %q{Rails integration for next generation PRX Authorization system.
-}
+  spec.description   = "Rails integration for next generation PRX Authorization system."
+  spec.summary       = "Rails integration for next generation PRX Authorization system."
   spec.homepage      = "https://github.com/PRX/prx_auth-rails"
   spec.license       = "MIT"
 
@@ -33,7 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'sqlite3'
 
-
-
-  spec.add_runtime_dependency 'prx_auth', "~> 1.2"
+  spec.add_runtime_dependency 'prx_auth', ">= 1.7.0"
 end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate!
 
+  def index; end
+
   def after_sign_in_path_for(_resource)
     '/after-sign-in-path'
   end

--- a/test/dummy/app/views/application/index.html.erb
+++ b/test/dummy/app/views/application/index.html.erb
@@ -1,0 +1,1 @@
+the controller index!

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
+  get 'index', to: 'application#index'
+  put 'index', to: 'application#index'
   mount PrxAuth::Rails::Engine => "/prx_auth-rails"
 end

--- a/test/prx_auth/rails/ext/controller_test.rb
+++ b/test/prx_auth/rails/ext/controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+module PrxAuth::Rails::Ext
+  class ControllerTest < ActionController::TestCase
+
+    setup do
+      @controller = ApplicationController.new
+      @jwt_session_key = ApplicationController::PRX_JWT_SESSION_KEY
+      @stub_claims = {'iat' => Time.now.to_i, 'exp' => Time.now.to_i + 3600}
+    end
+
+    test 'redirects unless you are authenticated' do
+      get :index
+      assert_equal response.code, '302'
+      assert response.headers['Location'].ends_with?('/sessions/new')
+    end
+
+    test 'uses a valid session token' do
+      session[@jwt_session_key] = 'some-jwt'
+      JSON::JWT.stub(:decode, @stub_claims) do
+        get :index
+        assert_equal response.code, '200'
+        assert response.body.include?('the controller index!')
+        assert @controller.current_user.is_a?(PrxAuth::Rails::Token)
+      end
+    end
+
+    test 'redirects if your token is nearing expiration' do
+      session[@jwt_session_key] = 'some-jwt'
+      @stub_claims['exp'] = Time.now.to_i + 10
+      JSON::JWT.stub(:decode, @stub_claims) do
+        get :index
+        assert_equal response.code, '302'
+        assert response.headers['Location'].ends_with?('/sessions/new')
+      end
+    end
+
+    test 'does not redirect if your token has expired on a non-GET request' do
+      session[@jwt_session_key] = 'some-jwt'
+      @stub_claims['exp'] = Time.now.to_i + 10
+      JSON::JWT.stub(:decode, @stub_claims) do
+        put :index
+        assert_equal response.code, '200'
+        assert response.body.include?('the controller index!')
+      end
+    end
+
+  end
+end

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -6,8 +6,10 @@ module PrxAuth::Rails
     setup do
       @routes = PrxAuth::Rails::Engine.routes
       @nonce_session_key = SessionsController::ID_NONCE_SESSION_KEY
+      @refresh_back_key = SessionsController::PRX_REFRESH_BACK_KEY
       @token_params = {id_token: 'idtok', access_token: 'accesstok'}
       @stub_claims = {'nonce' => '123', 'sub' => '1'}
+      @stub_token = PrxAuth::Rails::Token.new(Rack::PrxAuth::TokenData.new())
     end
 
     test "new creates nonce" do
@@ -33,7 +35,7 @@ module PrxAuth::Rails
     test 'create should validate a token and set the session variable' do
       session[SessionsController::PRX_JWT_SESSION_KEY] = nil
       @controller.stub(:validate_token, @stub_claims) do
-        @controller.stub(:fetch_accounts, []) do
+        @controller.stub(:session_token, @stub_token) do
           session[@nonce_session_key] = '123'
           post :create, params: @token_params, format: :json
           assert session[SessionsController::PRX_JWT_SESSION_KEY] == 'accesstok'
@@ -51,13 +53,27 @@ module PrxAuth::Rails
 
     test 'create should reset the nonce after consumed' do
       @controller.stub(:validate_token, @stub_claims) do
-        @controller.stub(:fetch_accounts, []) do
+        @controller.stub(:session_token, @stub_token) do
           session[@nonce_session_key] = '123'
           post :create, params: @token_params, format: :json
 
           assert session[@nonce_session_key] == nil
           assert response.code == '302'
           assert response.body.match?(/after-sign-in-path/)
+        end
+      end
+    end
+
+    test 'redirects to a back-path after refresh' do
+      @controller.stub(:validate_token, @stub_claims) do
+        @controller.stub(:session_token, @stub_token) do
+          session[@nonce_session_key] = '123'
+          session[@refresh_back_key] = '/lets/go/here?okay'
+          post :create, params: @token_params, format: :json
+
+          assert session[@refresh_back_key] == nil
+          assert response.code == '302'
+          assert response.headers['Location'].ends_with?('/lets/go/here?okay')
         end
       end
     end

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -33,7 +33,7 @@ module PrxAuth::Rails
     test 'create should validate a token and set the session variable' do
       session[SessionsController::PRX_JWT_SESSION_KEY] = nil
       @controller.stub(:validate_token, @stub_claims) do
-        @controller.stub(:lookup_and_register_accounts_names, nil) do
+        @controller.stub(:fetch_accounts, []) do
           session[@nonce_session_key] = '123'
           post :create, params: @token_params, format: :json
           assert session[SessionsController::PRX_JWT_SESSION_KEY] == 'accesstok'
@@ -51,7 +51,7 @@ module PrxAuth::Rails
 
     test 'create should reset the nonce after consumed' do
       @controller.stub(:validate_token, @stub_claims) do
-        @controller.stub(:lookup_and_register_accounts_names, nil) do
+        @controller.stub(:fetch_accounts, []) do
           session[@nonce_session_key] = '123'
           post :create, params: @token_params, format: :json
 

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -6,7 +6,7 @@ module PrxAuth::Rails
     setup do
       @routes = PrxAuth::Rails::Engine.routes
       @nonce_session_key = SessionsController::ID_NONCE_SESSION_KEY
-      @token_params = {id_token: 'sometok', access_token: 'othertok'}
+      @token_params = {id_token: 'idtok', access_token: 'accesstok'}
       @stub_claims = {'nonce' => '123', 'sub' => '1'}
     end
 
@@ -31,11 +31,12 @@ module PrxAuth::Rails
     end
 
     test 'create should validate a token and set the session variable' do
+      session[SessionsController::PRX_JWT_SESSION_KEY] = nil
       @controller.stub(:validate_token, @stub_claims) do
         @controller.stub(:lookup_and_register_accounts_names, nil) do
           session[@nonce_session_key] = '123'
           post :create, params: @token_params, format: :json
-          assert session['prx.auth']['id_token']['nonce'] == '123'
+          assert session[SessionsController::PRX_JWT_SESSION_KEY] == 'accesstok'
         end
       end
     end
@@ -96,9 +97,9 @@ module PrxAuth::Rails
     end
 
     test 'should clear the user token on sign out' do
-      session[PrxAuth::Rails::Controller::PRX_TOKEN_SESSION_KEY] = 'some-token'
+      session[SessionsController::PRX_JWT_SESSION_KEY] = 'some-token'
       post :destroy
-      assert session[PrxAuth::Rails::Controller::PRX_TOKEN_SESSION_KEY] == nil
+      assert session[SessionsController::PRX_JWT_SESSION_KEY] == nil
     end
   end
 end


### PR DESCRIPTION
Couple of changes to support using a JWT in Augury client-side javascript:

- [x] Instead of saving the decoded "access claims" (along with the appended-but-unused "ID token claims"), just save the access JWT to the session and decode it once every request.
- [x] When the token gets within 5 minutes of its expiration, throw the user back into the redirect/auth flow.  (Only on GET requests though).  Note that ID only issues 60-minute JWTs right now.
- [x] Make more effort to clear out / refresh session data.
- [x] Return all account metadata instead of just their "label".