### PR TITLE
Fix/401 redirects

### DIFF
--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PrxAuth::Rails
   class SessionsController < ApplicationController
     include PrxAuth::Rails::Engine.routes.url_helpers
@@ -6,7 +8,7 @@ module PrxAuth::Rails
 
     before_action :set_nonce!, only: [:new, :show]
 
-    ID_NONCE_SESSION_KEY = 'id_prx_openid_nonce'.freeze
+    ID_NONCE_SESSION_KEY = 'id_prx_openid_nonce'
 
     def new
       config = PrxAuth::Rails.configuration

--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -7,6 +7,7 @@ module PrxAuth::Rails
     skip_before_action :authenticate!
 
     before_action :set_nonce!, only: [:new, :show]
+    before_action :set_after_sign_in_path
 
     ID_NONCE_SESSION_KEY = 'id_prx_openid_nonce'
 

--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -8,19 +8,29 @@ module PrxAuth
 
       PRX_AUTH_ENV_KEY = 'prx.auth'.freeze
       PRX_JWT_SESSION_KEY = 'prx.auth.jwt'.freeze
+      # subtracted from the JWT ttl
       PRX_JWT_REFRESH_TTL = 300.freeze
       PRX_ACCOUNT_MAPPING_SESSION_KEY = 'prx.auth.account.mapping'.freeze
       PRX_USER_INFO_SESSION_KEY = 'prx.auth.info'.freeze
       PRX_REFRESH_BACK_KEY = 'prx.auth.back'.freeze
 
       def prx_auth_token
-        env_token || session_token
-      rescue SessionTokenExpiredError
-        session.delete(PRX_JWT_SESSION_KEY)
-        session.delete(PRX_ACCOUNT_MAPPING_SESSION_KEY)
-        session.delete(PRX_USER_INFO_SESSION_KEY)
+        set_after_sign_in_path
+
+        begin
+          env_token || session_token
+        rescue SessionTokenExpiredError
+          session.delete(PRX_JWT_SESSION_KEY)
+          session.delete(PRX_ACCOUNT_MAPPING_SESSION_KEY)
+          session.delete(PRX_USER_INFO_SESSION_KEY)
+          redirect_to PrxAuth::Rails::Engine.routes.url_helpers.new_sessions_path
+        end
+      end
+
+      def set_after_sign_in_path
+        return if self.class == PrxAuth::Rails::SessionsController
+
         session[PRX_REFRESH_BACK_KEY] = request.fullpath
-        redirect_to PrxAuth::Rails::Engine.routes.url_helpers.new_sessions_path
       end
 
       def prx_jwt
@@ -73,7 +83,7 @@ module PrxAuth
       end
 
       def after_sign_in_user_redirect
-        session.delete(PRX_REFRESH_BACK_KEY)
+        session[PRX_REFRESH_BACK_KEY]
       end
 
       def sign_out_user

--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -15,16 +15,12 @@ module PrxAuth
       PRX_REFRESH_BACK_KEY = 'prx.auth.back'.freeze
 
       def prx_auth_token
-        set_after_sign_in_path
-
-        begin
-          env_token || session_token
-        rescue SessionTokenExpiredError
-          session.delete(PRX_JWT_SESSION_KEY)
-          session.delete(PRX_ACCOUNT_MAPPING_SESSION_KEY)
-          session.delete(PRX_USER_INFO_SESSION_KEY)
-          nil
-        end
+        env_token || session_token
+      rescue SessionTokenExpiredError
+        session.delete(PRX_JWT_SESSION_KEY)
+        session.delete(PRX_ACCOUNT_MAPPING_SESSION_KEY)
+        session.delete(PRX_USER_INFO_SESSION_KEY)
+        nil
       end
 
       def set_after_sign_in_path

--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -23,7 +23,7 @@ module PrxAuth
           session.delete(PRX_JWT_SESSION_KEY)
           session.delete(PRX_ACCOUNT_MAPPING_SESSION_KEY)
           session.delete(PRX_USER_INFO_SESSION_KEY)
-          redirect_to PrxAuth::Rails::Engine.routes.url_helpers.new_sessions_path
+          nil
         end
       end
 

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -1,5 +1,5 @@
 module PrxAuth
   module Rails
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -71,7 +71,9 @@ module PrxAuth::Rails
           session[@refresh_back_key] = '/lets/go/here?okay'
           post :create, params: @token_params, format: :json
 
-          assert session[@refresh_back_key] == nil
+          # A trailing log of the 'last' page
+          assert session[@refresh_back_key] == '/lets/go/here?okay'
+
           assert response.code == '302'
           assert response.headers['Location'].ends_with?('/lets/go/here?okay')
         end


### PR DESCRIPTION
Fixes:

- Ensure that 401's from service call don't turn into 500s (that current_user is not truthy on redirect)
- Make sure that we don't lose our redirect destination on token expiration / back button.