### PR TITLE
Parse HAL accounts from ID

### DIFF
--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -116,7 +116,8 @@ module PrxAuth
 
       def fetch_accounts(ids)
         ids_param = ids.map(&:to_s).join(',')
-        fetch("/api/v1/accounts?account_ids=#{ids_param}")['accounts']
+        resp = fetch("/api/v1/accounts?account_ids=#{ids_param}")
+        resp.try(:[], '_embedded').try(:[], 'prx:items') || []
       end
 
       def fetch_userinfo

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -1,5 +1,5 @@
 module PrxAuth
   module Rails
-    VERSION = "2.1.0"
+    VERSION = "3.0.0"
   end
 end

--- a/test/prx_auth/rails/ext/controller_test.rb
+++ b/test/prx_auth/rails/ext/controller_test.rb
@@ -115,7 +115,7 @@ module PrxAuth::Rails::Ext
       with_stubbed_auth('some-jwt') do
         one = {'id' => 1, 'type' => 'IndividualAccount', 'name' => 'One'}
         three = {'id' => 3, 'type' => 'GroupAccount', 'name' => 'Three'}
-        body = {'accounts' => [one, three]}
+        body = {'_embedded' => {'prx:items' => [one, three]}}
 
         id_host = PrxAuth::Rails.configuration.id_host
         stub_request(:get, "https://#{id_host}/api/v1/accounts?account_ids=1,2,3").
@@ -135,7 +135,7 @@ module PrxAuth::Rails::Ext
       with_stubbed_auth('some-jwt') do
         id_host = PrxAuth::Rails.configuration.id_host
         stub_request(:get, "https://#{id_host}/api/v1/accounts?account_ids=2").
-          to_return(status: 200, body: JSON.generate({accounts: []})).
+          to_return(status: 200, body: JSON.generate({'_embedded' => {'prx:items' => []}})).
           times(3)
 
         assert_equal @controller.accounts_for([2]), [nil]
@@ -150,7 +150,7 @@ module PrxAuth::Rails::Ext
         two = {'id' => 2, 'type' => 'StationAccount', 'name' => 'Two'}
         three = {'name' => 'Three'}
         session[@account_mapping_key] = {1 => one, 3 => three}
-        body = {'accounts' => [two]}
+        body = {'_embedded' => {'prx:items' => [two]}}
 
         id_host = PrxAuth::Rails.configuration.id_host
         stub_request(:get, "https://#{id_host}/api/v1/accounts?account_ids=2").


### PR DESCRIPTION
ID is now outputting [HAL accounts](https://github.com/PRX/id.prx.org/blob/master/app/views/api/accounts/index.hal.jbuilder) (in addition to the deprecated syntax).  Switch to that!