### PR TITLE
Configure cert host

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ In your rails app, add a file to config/initializers called
 PrxAuth::Rails.configure do |config|
 
   # enables automatic installation of token parser middleware
-  config.install_middleware = false # default: true
+  config.install_middleware = true # default: true
+
+  # set the ID host
+  config.id_host = 'id.staging.prx.tech' # default: id.prx.org
 
   # automatically adds namespace to all scoped queries, e.g. .authorized?(:foo) will be treated
   # as .authorized?(:my_great_ns, :foo). Has no impact on unscoped queries.

--- a/lib/prx_auth/rails.rb
+++ b/lib/prx_auth/rails.rb
@@ -6,10 +6,36 @@ require "prx_auth/rails/engine" if defined?(Rails)
 module PrxAuth
   module Rails
     class << self
-      attr_accessor :configuration
+      attr_accessor :configuration, :installed_middleware
 
       def configure
-        yield configuration
+        yield configuration if block_given?
+
+        # only install from first call to configure block
+        if configuration.install_middleware && !installed_middleware
+          install_middleware!
+          self.installed_middleware = true
+        end
+      end
+
+      def install_middleware!(app = nil)
+        app ||= ::Rails.application if defined?(::Rails)
+
+        return false unless app
+
+        # guess protocol from host
+        host = configuration.id_host
+        path = configuration.cert_path
+        protocol =
+          if host.include?('localhost') || host.include?('127.0.0.1')
+            'http'
+          else
+            'https'
+          end
+
+        app.middleware.insert_after Rack::Head, Rack::PrxAuth,
+          cert_location: "#{protocol}://#{host}/#{path}",
+          issuer: host
       end
     end
 

--- a/lib/prx_auth/rails/configuration.rb
+++ b/lib/prx_auth/rails/configuration.rb
@@ -2,27 +2,34 @@ class PrxAuth::Rails::Configuration
   attr_accessor :install_middleware,
                 :namespace,
                 :prx_client_id,
-                :id_host
+                :id_host,
+                :cert_path
 
+  DEFAULT_ID_HOST = 'id.prx.org'
+  DEFAULT_CERT_PATH = 'api/v1/certs'
 
   def initialize
     @install_middleware = true
-    if defined?(::Rails)
-      klass = ::Rails.application.class
-      parent_name = if ::Rails::VERSION::MAJOR >= 6
-                      klass.module_parent_name
-                    else
-                      klass.parent_name
-                    end
-      klass_name = if parent_name.present?
-                     parent_name
-                   else
-                     klass.name
-                   end
+    @prx_client_id = nil
+    @id_host = DEFAULT_ID_HOST
+    @cert_path = DEFAULT_CERT_PATH
 
-      @namespace = klass_name.underscore.intern
-      @prx_client_id = nil
-      @id_host = nil
-    end
+    # infer default namespace from app name
+    @namespace =
+      if defined?(::Rails)
+        klass = ::Rails.application.class
+        parent_name = if ::Rails::VERSION::MAJOR >= 6
+                        klass.module_parent_name
+                      else
+                        klass.parent_name
+                      end
+        klass_name = if parent_name.present?
+                       parent_name
+                     else
+                       klass.name
+                     end
+
+        klass_name.underscore.intern
+      end
   end
 end

--- a/lib/prx_auth/rails/railtie.rb
+++ b/lib/prx_auth/rails/railtie.rb
@@ -7,11 +7,5 @@ module PrxAuth::Rails
     config.to_prepare do
       ApplicationController.send(:include, PrxAuth::Rails::Controller)
     end
-
-    initializer 'prx_auth.insert_middleware' do |app|
-      if PrxAuth::Rails.configuration.install_middleware
-        app.config.middleware.insert_after Rack::Head, Rack::PrxAuth
-      end
-    end
   end
 end

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -2,6 +2,6 @@
 
 module PrxAuth
   module Rails
-    VERSION = '3.0.1'
+    VERSION = '4.0.0'
   end
 end

--- a/test/prx_auth/rails/configuration_test.rb
+++ b/test/prx_auth/rails/configuration_test.rb
@@ -4,33 +4,32 @@ describe PrxAuth::Rails::Configuration do
 
   subject { PrxAuth::Rails::Configuration.new }
 
-  it 'initializes with a namespace defined by rails app name' do
-    assert subject.namespace == :dummy
+  it 'initializes with defaults' do
+    assert subject.install_middleware
+    assert_nil subject.prx_client_id
+    assert_equal 'id.prx.org', subject.id_host
+    assert_equal 'api/v1/certs', subject.cert_path
   end
 
-  it 'can be reconfigured using the namespace attr' do
-    PrxAuth::Rails.stub(:configuration, subject) do
-      PrxAuth::Rails.configure do |config|
-        config.namespace = :new_test
-      end
-
-      assert PrxAuth::Rails.configuration.namespace == :new_test
-    end
+  it 'infers the default namespace from the rails app name' do
+    assert_equal :dummy, subject.namespace
   end
 
-  it 'defaults to enabling the middleware' do
-    PrxAuth::Rails.stub(:configuration, subject) do
-      assert PrxAuth::Rails.configuration.install_middleware
-    end
-  end
-
-  it 'allows overriding of the middleware automatic installation' do
+  it 'is updated by the prxauth configure block' do
     PrxAuth::Rails.stub(:configuration, subject) do
       PrxAuth::Rails.configure do |config|
         config.install_middleware = false
+        config.prx_client_id = 'some-id'
+        config.id_host = 'id.prx.blah'
+        config.cert_path = 'cert/path'
+        config.namespace = :new_test
       end
-
-      assert !PrxAuth::Rails.configuration.install_middleware
     end
+
+    refute subject.install_middleware
+    assert_equal 'some-id', subject.prx_client_id
+    assert_equal 'id.prx.blah', subject.id_host
+    assert_equal 'cert/path', subject.cert_path
+    assert_equal :new_test, subject.namespace
   end
 end

--- a/test/prx_auth/rails_test.rb
+++ b/test/prx_auth/rails_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+require 'pry'
+
+describe PrxAuth::Rails do
+
+  subject { PrxAuth::Rails }
+
+  it 'gets a configuration' do
+    assert_equal :test_app, subject.configuration.namespace
+    assert_equal '1234', subject.configuration.prx_client_id
+    assert_equal 'id.prx.test', subject.configuration.id_host
+    assert_equal 'api/v1/certs', subject.configuration.cert_path
+  end
+
+  it 'installs and configures prx_auth middleware' do
+    mw = MiniTest::Mock.new
+    mw.expect :insert_after, nil do |c1, c2, cert_location:, issuer:|
+      assert_equal Rack::Head, c1
+      assert_equal Rack::PrxAuth, c2
+      assert_equal 'https://id.prx.test/api/v1/certs', cert_location
+      assert_equal 'id.prx.test', issuer
+    end
+
+    app = MiniTest::Mock.new
+    app.expect :middleware, mw
+
+    subject.install_middleware!(app)
+    mw.verify
+  end
+
+  it 'installs middleware after configuration' do
+    called = false
+    spy = -> { called = true }
+
+    PrxAuth::Rails.stub(:install_middleware!, spy) do
+      PrxAuth::Rails.installed_middleware = false
+
+      PrxAuth::Rails.configure do |config|
+        config.install_middleware = true
+      end
+
+      assert PrxAuth::Rails.installed_middleware
+    end
+
+    assert called
+  end
+
+  it 'allows overriding of the middleware automatic installation' do
+    called = false
+    spy = -> { called = true }
+
+    PrxAuth::Rails.stub(:install_middleware!, spy) do
+      PrxAuth::Rails.installed_middleware = false
+
+      PrxAuth::Rails.configure do |config|
+        config.install_middleware = false
+      end
+
+      refute PrxAuth::Rails.installed_middleware
+    end
+
+    refute called
+  end
+end


### PR DESCRIPTION
Fixes #5.

Most of our apps were adding the middleware twice.

1. Once in `config/application.rb`, where we were explicitly setting the cert location
2. Once in `config/initializers/prx_auth.rb`, because even if you configured `install_middleware = false` ... the railtie was adding the initializer before that was set.

This gets rid of the need for `config/application.rb` explicit middleware and the auto-railtie middleware.  Instead it adds the middleware _after_ your call to `PrxAuth::Rails.configure`.

Bonus: it also configures PrxAuth with the same `id_host` you set in that configure block.