### PR TITLE
Except resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in prx_auth-rails.gemspec
 gemspec
-
-gem "prx_auth", github: "PRX/prx_auth", branch: "feat/except_resources"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in prx_auth-rails.gemspec
 gemspec
+
+gem "prx_auth", github: "PRX/prx_auth", branch: "feat/except_resources"

--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -10,7 +10,7 @@ module PrxAuth::Rails
     before_action :set_after_sign_in_path
 
     ID_NONCE_SESSION_KEY = "id_prx_openid_nonce"
-    DEFAULT_SCOPES = "openid apps"
+    DEFAULT_SCOPES = "openid"
 
     def new
       config = PrxAuth::Rails.configuration

--- a/app/views/prx_auth/rails/sessions/auth_error.html.erb
+++ b/app/views/prx_auth/rails/sessions/auth_error.html.erb
@@ -1,13 +1,6 @@
 <div class='main'>
   <section>
     <h3>Not authorized for this application.</h3>
-
-    <p>Message was: <pre><%= @auth_error_message %></pre>
-    <% if  @auth_error_message == 'invalid_scope' %>
-      Did you add a row in the account_applications table on id.prx?
-    <% end %>
-    </p>
-
     <p>
       <a href="<%= new_sessions_path %>">Try logging in again</a>
     </p>

--- a/lib/prx_auth/rails/token.rb
+++ b/lib/prx_auth/rails/token.rb
@@ -32,4 +32,13 @@ class PrxAuth::Rails::Token
   def authorized_account_ids(scope)
     @token_data.authorized_account_ids(scope)
   end
+
+  def except!(*resources)
+    @token_data = @token_data.except(*resources)
+    self
+  end
+
+  def except(*resources)
+    dup.except!(*resources)
+  end
 end

--- a/lib/prx_auth/rails/token.rb
+++ b/lib/prx_auth/rails/token.rb
@@ -41,4 +41,8 @@ class PrxAuth::Rails::Token
   def except(*resources)
     dup.except!(*resources)
   end
+
+  def empty_resources?
+    @token_data.empty_resources?
+  end
 end

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -2,6 +2,6 @@
 
 module PrxAuth
   module Rails
-    VERSION = "4.1.0"
+    VERSION = "4.2.0"
   end
 end

--- a/prx_auth-rails.gemspec
+++ b/prx_auth-rails.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "standard"
 
-  spec.add_runtime_dependency "prx_auth", ">= 1.7.0"
+  spec.add_runtime_dependency "prx_auth", ">= 1.8.0"
 end

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -92,7 +92,7 @@ module PrxAuth::Rails
     test "auth_error should return a formatted error message to the user" do
       get :auth_error, params: {error: "error_message"}
       assert response.code == "200"
-      assert response.body.match?(/Message was: <pre>error_message/)
+      assert response.body.match?(/Not authorized/)
     end
 
     test "auth_error should expect the error param" do

--- a/test/prx_auth/rails/token_test.rb
+++ b/test/prx_auth/rails/token_test.rb
@@ -55,4 +55,19 @@ describe PrxAuth::Rails::Token do
     token.except!("123")
     refute token.authorized?("123", :read)
   end
+
+  it "checks for empty resources" do
+    # wilcard tokens are never empty
+    refute token.empty_resources?
+    refute token.except("123").empty_resources?
+
+    # non-wildcard token
+    aur2 = {"123" => "anything"}
+    token_data2 = Rack::PrxAuth::TokenData.new("aur" => aur2, "scope" => scope, "sub" => sub)
+    mock_token_data2 = Minitest::Mock.new(token_data2)
+    token2 = PrxAuth::Rails::Token.new(mock_token_data2)
+
+    refute token2.empty_resources?
+    assert token2.except("123").empty_resources?
+  end
 end

--- a/test/prx_auth/rails/token_test.rb
+++ b/test/prx_auth/rails/token_test.rb
@@ -40,4 +40,19 @@ describe PrxAuth::Rails::Token do
     assert token.globally_authorized?(:test_app, :add)
     assert !token.globally_authorized?(:other_namespace, :add)
   end
+
+  it "returns a token except resources" do
+    token2 = token.except("123")
+
+    assert token.authorized?("123", :read)
+    refute token2.authorized?("123", :read)
+
+    # BUT cannot remove wildcard resources
+    assert token.authorized?("123", :add)
+    assert token2.authorized?("123", :add)
+
+    # the ! version modifies
+    token.except!("123")
+    refute token.authorized?("123", :read)
+  end
 end


### PR DESCRIPTION
After PRX/prx_auth#34.

- Adds `except` methods on token
- Stop asking for `apps` scope (deprecating account_applications)