### PR TITLE
PRX admins

### DIFF
--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -22,10 +22,9 @@ module PrxAuth::Rails
       }
 
       if session[WILDCARD_SESSION_KEY]
-        # TODO: wait for ID to update to prx_auth 1.8.1, then remove next line
-        id_auth_params[:scope] = DEFAULT_SCOPES
         id_auth_params[:account] = "*"
-        id_auth_params[:scope] += " read-private" if session[WILDCARD_SESSION_KEY] == "readonly"
+        # TODO: what if they need more than _just_ read-private?
+        id_auth_params[:scope] = "#{DEFAULT_SCOPES} read-private" if session[WILDCARD_SESSION_KEY] == "readonly"
       end
 
       url = "//" + config.id_host + "/authorize?" + id_auth_params.to_query

--- a/app/helpers/prx_auth/rails/sessions_helper.rb
+++ b/app/helpers/prx_auth/rails/sessions_helper.rb
@@ -1,0 +1,27 @@
+module PrxAuth::Rails
+  module SessionsHelper
+    def current_user_app?(name)
+      current_user && current_user_app(name).present?
+    end
+
+    def current_user_app(name)
+      current_user_apps.find { |key, url| key.downcase.include?(name) }&.last
+    end
+
+    def current_user_id_profile
+      "https://#{PrxAuth::Rails.configuration.id_host}/profile"
+    end
+
+    def current_user_id_accounts
+      "https://#{PrxAuth::Rails.configuration.id_host}/accounts"
+    end
+
+    def current_user_image?
+      current_user && current_user_image.present?
+    end
+
+    def current_user_image
+      current_user_info["image_href"]
+    end
+  end
+end

--- a/app/views/prx_auth/rails/sessions/access_error.html.erb
+++ b/app/views/prx_auth/rails/sessions/access_error.html.erb
@@ -1,0 +1,20 @@
+<div class="row">
+
+  <div class="col-lg-3"></div>
+
+  <div class="col-lg-6 my-5">
+    <div class="card">
+      <div class="card-body my-2">
+        <h1 class="card-title text-center">Not Authorized</h1>
+        <p class="card-text text-center">
+          <%= link_to "Your accounts", current_user_id_accounts %> are not authorized to use this PRX application.
+          <br/>
+          If you believe this to be in error, please <a href="https://help.prx.org/hc/en-us">contact PRX support.</a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-3"></div>
+
+</div>

--- a/app/views/prx_auth/rails/sessions/auth_error.html.erb
+++ b/app/views/prx_auth/rails/sessions/auth_error.html.erb
@@ -1,8 +1,20 @@
-<div class='main'>
-  <section>
-    <h3>Not authorized for this application.</h3>
-    <p>
-      <a href="<%= new_sessions_path %>">Try logging in again</a>
-    </p>
-  </section>
+<div class="row">
+
+  <div class="col-lg-3"></div>
+
+  <div class="col-lg-6 my-5">
+    <div class="card">
+      <div class="card-body my-2">
+        <h1 class="card-title text-center"><%= @auth_error_message&.titleize || "Unknown" %> Error</h1>
+        <p class="card-text text-center">
+          Something went terribly wrong - please <%= link_to "try logging in again", new_sessions_path %>.
+          <br/>
+          If the problem persists, <a href="https://help.prx.org/hc/en-us">contact PRX support.</a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-3"></div>
+
 </div>

--- a/app/views/prx_auth/rails/sessions/show.html.erb
+++ b/app/views/prx_auth/rails/sessions/show.html.erb
@@ -1,5 +1,5 @@
 <div style="display:none;">
-  <%= form_for(:sessions, :url => PrxAuth::Rails::Engine.routes.url_helpers.sessions_path) do |f| %>
+  <%= form_for(:sessions, url: sessions_path) do |f| %>
       <%= hidden_field_tag :access_token, '', id: 'access-token-field' %>
       <%= hidden_field_tag :id_token, '', id: 'id-token-field' %>
       <%= hidden_field_tag :error, '', id: 'error-field' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
-PrxAuth::Rails::Engine.routes.draw do
-  scope module: "prx_auth/rails" do
-    resource "sessions", defaults: {format: "html"} do
+Rails.application.routes.draw do
+  scope module: "prx_auth/rails", path: "auth" do
+    resource "sessions", except: %w[edit update] do
+      get "access_error", to: "sessions#access_error"
       get "auth_error", to: "sessions#auth_error"
+      get "logout", to: "sessions#logout"
+      get "refresh", to: "sessions#refresh"
     end
   end
 end

--- a/lib/prx_auth/rails/engine.rb
+++ b/lib/prx_auth/rails/engine.rb
@@ -4,6 +4,7 @@ module PrxAuth
       config.to_prepare do
         ::ApplicationController.helper_method [
           :current_user, :prx_jwt,
+          :current_user_access?, :current_user_admin?, :current_user_wildcard?,
           :current_user_info, :current_user_name, :current_user_apps,
           :account_name_for, :account_for, :accounts_for
         ]

--- a/lib/prx_auth/rails/ext/controller/account_info.rb
+++ b/lib/prx_auth/rails/ext/controller/account_info.rb
@@ -1,0 +1,51 @@
+require "open-uri"
+
+module PrxAuth
+  module Rails
+    module AccountInfo
+      PRX_ACCOUNT_MAPPING_SESSION_KEY = "prx.auth.account.mapping".freeze
+
+      def account_name_for(account_id)
+        account_for(account_id).try(:[], "name")
+      end
+
+      def account_for(account_id)
+        lookup_accounts([account_id]).first
+      end
+
+      def accounts_for(account_ids)
+        lookup_accounts(account_ids)
+      end
+
+      private
+
+      def lookup_accounts(ids)
+        return fetch_accounts(ids) unless defined?(session)
+
+        session[PRX_ACCOUNT_MAPPING_SESSION_KEY] ||= {}
+
+        # fetch any accounts we don't have yet
+        missing = ids - session[PRX_ACCOUNT_MAPPING_SESSION_KEY].keys
+        if missing.present?
+          fetch_accounts(missing).each do |account|
+            minimal = account.slice("name", "type")
+            session[PRX_ACCOUNT_MAPPING_SESSION_KEY][account["id"]] = minimal
+          end
+        end
+
+        ids.map { |id| session[PRX_ACCOUNT_MAPPING_SESSION_KEY][id] }
+      end
+
+      def fetch_accounts(ids)
+        ids_param = ids.map(&:to_s).join(",")
+        path = "/api/v1/accounts?account_ids=#{ids_param}"
+        url = "https://#{PrxAuth::Rails.configuration.id_host}#{path}"
+
+        options = {}
+        options[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE if ::Rails.env.development?
+        resp = JSON.parse(URI.open(url, options).read) # standard:disable Security/Open
+        resp.try(:[], "_embedded").try(:[], "prx:items") || []
+      end
+    end
+  end
+end

--- a/lib/prx_auth/rails/ext/controller/user_info.rb
+++ b/lib/prx_auth/rails/ext/controller/user_info.rb
@@ -1,0 +1,62 @@
+require "open-uri"
+
+module PrxAuth
+  module Rails
+    module UserInfo
+      PRX_USER_INFO_SESSION_KEY = "prx.auth.info".freeze
+      PRX_ADMIN_SCOPE = "prxadmin".freeze
+
+      def current_user
+        prx_auth_token
+      end
+
+      def current_user_access?(scope = :read_private)
+        current_user&.globally_authorized?(scope) || current_user&.authorized_account_ids(scope)&.any?
+      end
+
+      def current_user_info
+        session[PRX_USER_INFO_SESSION_KEY] ||= begin
+          info = fetch_userinfo
+          info.slice("name", "preferred_username", "email", "image_href", "apps")
+        end
+      end
+
+      def current_user_name
+        current_user_info["name"] || current_user_info["preferred_username"] || current_user_info["email"]
+      end
+
+      def current_user_apps
+        apps = (current_user_info.try(:[], "apps") || []).map do |name, url|
+          label = name.sub(/^https?:\/\//, "").sub(/\..+/, "").capitalize
+          ["PRX #{label}", url]
+        end
+
+        # only return entire list in development
+        if ::Rails.env.production? || ::Rails.env.staging?
+          apps.to_h.select { |k, v| v.match?(/\.(org|tech)/) }
+        else
+          apps.to_h
+        end
+      end
+
+      def current_user_admin?
+        current_user&.scopes&.include?(PRX_ADMIN_SCOPE)
+      end
+
+      def current_user_wildcard?
+        current_user&.globally_authorized?(:read_private)
+      end
+
+      private
+
+      def fetch_userinfo
+        path = "/userinfo?scope=apps+email+profile"
+        url = "https://#{PrxAuth::Rails.configuration.id_host}#{path}"
+        options = {}
+        options[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE if ::Rails.env.development?
+        options["Authorization"] = "Bearer #{prx_jwt}"
+        JSON.parse(URI.open(url, options).read) # standard:disable Security/Open
+      end
+    end
+  end
+end

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -2,6 +2,6 @@
 
 module PrxAuth
   module Rails
-    VERSION = "4.3.0"
+    VERSION = "5.0.0"
   end
 end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
   def index
   end
+
+  def after_sign_in_path_for(_resource)
+    "/after-sign-in-path"
+  end
 end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,10 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate!
-
   def index
-  end
-
-  def after_sign_in_path_for(_resource)
-    "/after-sign-in-path"
   end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
   get "index", to: "application#index"
   put "index", to: "application#index"
-  mount PrxAuth::Rails::Engine => "/prx_auth-rails"
 end

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -3,9 +3,10 @@ require "test_helper"
 module PrxAuth::Rails
   class SessionsControllerTest < ActionController::TestCase
     setup do
-      @routes = PrxAuth::Rails::Engine.routes
+      @jwt_key = SessionsController::PRX_JWT_SESSION_KEY
       @nonce_session_key = SessionsController::ID_NONCE_SESSION_KEY
       @refresh_back_key = SessionsController::PRX_REFRESH_BACK_KEY
+      @wildcard_key = SessionsController::WILDCARD_SESSION_KEY
       @token_params = {id_token: "idtok", access_token: "accesstok"}
       @stub_claims = {"nonce" => "123", "sub" => "1"}
       @stub_token = PrxAuth::Rails::Token.new(Rack::PrxAuth::TokenData.new)
@@ -31,13 +32,30 @@ module PrxAuth::Rails
       assert nonce1 == nonce2
     end
 
+    test "new includes scopes and accounts" do
+      get :new
+      assert response.code == "302"
+      assert_includes response.location, "scope=openid"
+
+      PrxAuth::Rails.configuration.prx_scope = "feeder:*"
+      get :new
+      assert response.code == "302"
+      assert_includes response.location, "scope=openid+feeder%3A%2A"
+
+      session[@wildcard_key] = "true"
+      get :new
+      assert response.code == "302"
+      assert_includes response.location, "scope=openid"
+      assert_includes response.location, "account=%2A"
+    end
+
     test "create should validate a token and set the session variable" do
-      session[SessionsController::PRX_JWT_SESSION_KEY] = nil
+      session[@jwt_key] = nil
       @controller.stub(:validate_token, @stub_claims) do
         @controller.stub(:session_token, @stub_token) do
           session[@nonce_session_key] = "123"
           post :create, params: @token_params, format: :json
-          assert session[SessionsController::PRX_JWT_SESSION_KEY] == "accesstok"
+          assert session[@jwt_key] == "accesstok"
         end
       end
     end
@@ -90,9 +108,9 @@ module PrxAuth::Rails
     end
 
     test "auth_error should return a formatted error message to the user" do
-      get :auth_error, params: {error: "error_message"}
+      get :auth_error, params: {error: "bad_things"}
       assert response.code == "200"
-      assert response.body.match?(/Not authorized/)
+      assert response.body.match?(/Bad Things Error/)
     end
 
     test "auth_error should expect the error param" do
@@ -115,9 +133,36 @@ module PrxAuth::Rails
     end
 
     test "should clear the user token on sign out" do
-      session[SessionsController::PRX_JWT_SESSION_KEY] = "some-token"
+      session[@jwt_key] = "some-token"
       post :destroy
-      assert session[SessionsController::PRX_JWT_SESSION_KEY].nil?
+      assert session[@jwt_key].nil?
+    end
+
+    test "should clear the user token and send to ID on logout" do
+      session[@jwt_key] = "some-token"
+      get :logout
+      assert session[@jwt_key].nil?
+      assert response.code == "302"
+      assert_equal "//id.prx.test/session/sign_out", response.location
+    end
+
+    test "refreshes auth" do
+      session[@jwt_key] = "some-token"
+      get :refresh
+      assert session[@jwt_key].nil?
+      assert response.code == "302"
+      assert_includes response.location, new_sessions_path
+    end
+
+    test "refreshes wildcard auth for admins" do
+      @controller.stub(:current_user_admin?, true) do
+        session[@jwt_key] = "some-token"
+        get :refresh, params: {wildcard: true}
+        assert session[@jwt_key].nil?
+        assert session[@wildcard_key] = "true"
+        assert response.code == "302"
+        assert_includes response.location, new_sessions_path
+      end
     end
   end
 end

--- a/test/prx_auth/rails/sessions_helper_test.rb
+++ b/test/prx_auth/rails/sessions_helper_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class TestHelper
+  attr_accessor :current_user, :current_user_apps, :current_user_info
+  include PrxAuth::Rails::SessionsHelper
+end
+
+describe PrxAuth::Rails::SessionsHelper do
+  let(:helper) { TestHelper.new }
+
+  describe "#current_user_app?" do
+    it "makes sure there is a current user" do
+      helper.current_user = nil
+      refute helper.current_user_app?("foo")
+      refute helper.current_user_app?("bar")
+    end
+
+    it "determines if you have an app or not" do
+      helper.current_user = {}
+      helper.current_user_apps = {
+        "app for BAR" => "https://bar.prx.org",
+        "and then BAZ" => "https://baz.staging.prx.tech"
+      }
+
+      refute helper.current_user_app?("foo")
+      assert helper.current_user_app?("bar")
+      assert helper.current_user_app?("baz")
+    end
+  end
+
+  describe "#current_user_app" do
+    it "returns app urls" do
+      helper.current_user = {}
+      helper.current_user_apps = {
+        "dev domain" => "https://foo.prx.dev",
+        "real Bar domain" => "https://bar.prx.org",
+        "staging Baz domain" => "https://baz.staging.prx.tech"
+      }
+
+      assert_nil helper.current_user_app("foo")
+      assert_equal "https://bar.prx.org", helper.current_user_app("bar")
+      assert_equal "https://baz.staging.prx.tech", helper.current_user_app("baz")
+    end
+  end
+
+  describe "#current_user_id_profile" do
+    it "returns the ID host" do
+      assert_includes helper.current_user_id_profile, PrxAuth::Rails.configuration.id_host
+    end
+  end
+
+  describe "#current_user_image?" do
+    it "checks if the user has an image" do
+      refute helper.current_user_image?
+
+      helper.current_user = {}
+      helper.current_user_info = {"image_href" => ""}
+      refute helper.current_user_image?
+
+      helper.current_user_info = {"image_href" => "http://some.where/img"}
+      assert helper.current_user_image?
+    end
+  end
+
+  describe "#current_user_image" do
+    it "returns the user image url" do
+      helper.current_user_info = {"image_href" => "http://some.where/img"}
+      assert_equal "http://some.where/img", helper.current_user_image
+    end
+  end
+end


### PR DESCRIPTION
Adds support for prx admins, wildcard access, and consolidates some code we've been copying from app-to-app.

- [x] Installing this gem now automatically adds routes - no need to edit your app's routes.rb
- [x] No more need to reference `main_app` in shared app layouts.  The auth session paths are now part of the main app.
- [x] Automatically check if user has `read-private` in the app's namespace.  If not, render an `access_error` page (copied from Feeder).
  - _You can customize this by overriding the `current_user_access?` method in your ApplicationController_
- [x] Port the "current user" view helper into this gem
- [x] Adds `current_user_admin?` helper method to check if the user has `prxadmin` scope (and could get ActiveAdmin access in the app)
- [x] Adds `current_user_wildcard?` helper method to check if the user is currently using wildcard access
- [x] Can now send admin users to `refresh_sessions_path(wildcard: true)` or `refresh_sessions_path(wildcard: "readonly")` paths to fetch a wildcard ID token.