### PR TITLE
Still need the apps scope

### DIFF
--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -8,7 +8,7 @@ module PrxAuth::Rails
 
     ID_NONCE_SESSION_KEY = "id_prx_openid_nonce"
     WILDCARD_SESSION_KEY = "prx.auth.wildcard"
-    DEFAULT_SCOPES = "openid"
+    DEFAULT_SCOPES = "openid apps"
 
     def new
       config = PrxAuth::Rails.configuration

--- a/lib/prx_auth/rails/version.rb
+++ b/lib/prx_auth/rails/version.rb
@@ -2,6 +2,6 @@
 
 module PrxAuth
   module Rails
-    VERSION = "5.0.0"
+    VERSION = "5.0.1"
   end
 end

--- a/test/prx_auth/rails/sessions_controller_test.rb
+++ b/test/prx_auth/rails/sessions_controller_test.rb
@@ -40,7 +40,7 @@ module PrxAuth::Rails
       PrxAuth::Rails.configuration.prx_scope = "feeder:*"
       get :new
       assert response.code == "302"
-      assert_includes response.location, "scope=openid+feeder%3A%2A"
+      assert_includes response.location, "scope=openid+apps+feeder%3A%2A"
 
       session[@wildcard_key] = "true"
       get :new


### PR DESCRIPTION
The `current_user_apps` method was returning blank, as the JWT we asked for no longer had the scope to ask for apps.