### PR TITLE
After sign in path

### DIFF
--- a/app/controllers/prx_auth/rails/sessions_controller.rb
+++ b/app/controllers/prx_auth/rails/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 module PrxAuth::Rails
   class SessionsController < ApplicationController
-    skip_before_action :set_after_sign_in_path, :authenticate!, raise: false
+    skip_before_action :authenticate!, raise: false
 
     before_action :set_nonce!, only: [:new, :show]
 
@@ -70,6 +70,7 @@ module PrxAuth::Rails
       sign_out_user
       session[WILDCARD_SESSION_KEY] = wildcard
 
+      set_after_sign_in_path(request.referer.presence || "/")
       redirect_to new_sessions_path
     end
 

--- a/lib/prx_auth/rails.rb
+++ b/lib/prx_auth/rails.rb
@@ -28,7 +28,7 @@ module PrxAuth
         host = configuration.id_host
         path = configuration.cert_path
         protocol =
-          if host.include?("localhost") || host.include?("127.0.0.1")
+          if host&.include?("localhost") || host&.include?("127.0.0.1")
             "http"
           else
             "https"

--- a/lib/prx_auth/rails/ext/controller.rb
+++ b/lib/prx_auth/rails/ext/controller.rb
@@ -18,7 +18,7 @@ module PrxAuth
       PRX_REFRESH_BACK_KEY = "prx.auth.back".freeze
 
       included do
-        before_action :set_after_sign_in_path, :authenticate!
+        before_action :authenticate!
       end
 
       def prx_auth_token
@@ -30,8 +30,8 @@ module PrxAuth
         nil
       end
 
-      def set_after_sign_in_path
-        session[PRX_REFRESH_BACK_KEY] = request.fullpath
+      def set_after_sign_in_path(path = nil)
+        session[PRX_REFRESH_BACK_KEY] = path || request.fullpath
       end
 
       def prx_jwt
@@ -44,6 +44,7 @@ module PrxAuth
 
       def authenticate!
         if !current_user
+          set_after_sign_in_path
           redirect_to new_sessions_path
         elsif !current_user_access?
           redirect_to access_error_sessions_path


### PR DESCRIPTION
Fixes #27.

As a bonus, handle nil `ID_HOST`s, so you can run a test suite without needing to set that.  (My `config/prx_auth.rb` initializer was erroring).